### PR TITLE
Added custom url input field, show source button more examples in the cheat sheet

### DIFF
--- a/Whoaverse/Whoaverse/Content/markdowneditor.css
+++ b/Whoaverse/Whoaverse/Content/markdowneditor.css
@@ -21,7 +21,8 @@
 	display: inline-block;
 	margin-top: 2px;
 	margin-bottom: 2px;
-	margin-right: 2px;
+	margin-left: 1px;
+	margin-right: 1px;
 	height: 16px;
 	width: 32px;
 	vertical-align: middle;
@@ -33,7 +34,10 @@
 }
 .markdownEditorTextButton{
 	display: inline-block;
-	margin: 1px;
+	margin-top: 2px;
+	margin-bottom: 2px;
+	margin-left: 1px;
+	margin-right: 1px;
 	padding: 0px 2px 1px 2px;
 	
 	min-width: 32px;

--- a/Whoaverse/Whoaverse/Scripts/markdownEditor.js
+++ b/Whoaverse/Whoaverse/Scripts/markdownEditor.js
@@ -189,9 +189,12 @@ function createTable(textComponent, numColumns, numRows) {
     }
 }
 
-function addHyperlink(textComponent) {
-    //this will be replaced with a custom dialog in future versions
-    var url = prompt('Enter the URL: ', '');
+/*
+ * Creates the markdown for the hyperlink
+ * textComponent:		the textarea
+ * url:					the hyperlink's target
+ */
+function addHyperlink(textComponent, url) {
     if (url != "" && url !== null) {
 		if (getSelectionArray(textComponent)[1] == ""){
 			//No text selected, add "Title Here" to help user understand the markdown

--- a/Whoaverse/Whoaverse/Views/Help/markdown.cshtml
+++ b/Whoaverse/Whoaverse/Views/Help/markdown.cshtml
@@ -33,16 +33,32 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td>*italics*</td>
-                            <td><i>italics</i></td>
-                        </tr>
-                        <tr>
                             <td>**bold**</td>
                             <td><b>bold</b></td>
                         </tr>
                         <tr>
+                            <td>*italics*</td>
+                            <td><i>italics</i></td>
+                        </tr>
+                        <tr>
                             <td>[Yay, a Google!](http://google.com)</td>
                             <td><a href="http://google.com">Yay, a Google!</a></td>
+                        </tr>
+                        <tr>
+                            <td>
+                                > Quoting is awesome.<br />
+                                > Yes, quoting is awesome.<br />
+                            </td>
+                            <td>
+                                <blockquote class="small">
+                                    <p>
+                                        Quoting is awesome.
+                                    </p>
+                                    <p>
+                                        Yes, quoting is awesome.
+                                    </p>
+                                </blockquote>
+                            </td>
                         </tr>
                         <tr>
                             <td>
@@ -54,6 +70,50 @@
                                 <pre><code>Code block</code></pre>
                             </td>
                         </tr>
+						<tr>
+							<td>
+								* Anna<br />
+								* Bob<br />
+								* Charlie
+							</td>
+							<td>
+								<ul style="list-style-type: disc;">
+									<li>Anna</li>
+									<li>Bob</li>
+									<li>Charlie</li>
+								</ul>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								1. Make a comment<br />
+								2. Use Markdown<br />
+								3. ???<br />
+								4. Profit
+							</td>
+							<td>
+								<ol style="list-style-type: decimal;">
+									<li>Make a comment</li>
+									<li>Use Markdown</li>
+									<li>???</li>
+									<li>Profit</li>
+								</ol>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								Paragraph 1<br />
+								<br />
+								----------<br />
+								<br />
+								Paragraph 2
+							</td>
+							<td>
+								<p>Paragraph 1</p>
+								<hr>
+								<p>Paragraph 2</p>
+							</td>
+						</tr>
                         <tr>
                             <td>
                                 Fruit    |Color<br />
@@ -85,22 +145,6 @@
                                         </tr>
                                     </tbody>
                                 </table>
-                        </tr>
-                        <tr>
-                            <td>
-                                > Quoting is awesome.<br />
-                                > Yes, quoting is awesome.<br />
-                            </td>
-                            <td>
-                                <blockquote class="small">
-                                    <p>
-                                        Quoting is awesome.
-                                    </p>
-                                    <p>
-                                        Yes, quoting is awesome.
-                                    </p>
-                                </blockquote>
-                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/Whoaverse/Whoaverse/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml
@@ -30,6 +30,9 @@
         if (User.Identity.Name == commentAuthor)
         {
             <li>
+                <a class="" href="javascript:void(0)" onclick="$(this.parentElement.parentElement.parentElement).find('#sourceDisplay')[0].slideToggle();">source</a>
+            </li>
+			<li>
                 <a class="" href="javascript:void(0)" onclick="return edit(@commentId, @Model.CommentModel.MessageId)">edit</a>
             </li>
 

--- a/Whoaverse/Whoaverse/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml
@@ -27,11 +27,14 @@
 
     @if (User.Identity.IsAuthenticated)
     {
-        if (User.Identity.Name == commentAuthor)
-        {
+        if (User.Identity.Name != "deleted" && User.Identity.Name != commentAuthor)
+		{
             <li>
                 <a class="" href="javascript:void(0)" onclick="$(this.parentElement.parentElement.parentElement).find('#sourceDisplay')[0].slideToggle();">source</a>
             </li>
+		}
+		if (User.Identity.Name == commentAuthor)
+        {
 			<li>
                 <a class="" href="javascript:void(0)" onclick="return edit(@commentId, @Model.CommentModel.MessageId)">edit</a>
             </li>

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml
@@ -23,11 +23,14 @@
 
     @if (User.Identity.IsAuthenticated)
     {
-        if (User.Identity.Name == Model.Name)
-        {
+		if (User.Identity.Name != "deleted" && User.Identity.Name != Model.Name)
+		{
 			<li>
                 <a class="" href="javascript:void(0)" onclick="$(this.parentElement.parentElement.parentElement).find('#sourceDisplay')[0].slideToggle();">source</a>
             </li>
+		}
+        if (User.Identity.Name == Model.Name)
+        {
             <li>
                 <a class="" href="#submissionTop" onclick="return editsubmission(@Model.Id)">edit</a>
             </li>

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml
@@ -25,6 +25,9 @@
     {
         if (User.Identity.Name == Model.Name)
         {
+			<li>
+                <a class="" href="javascript:void(0)" onclick="$(this.parentElement.parentElement.parentElement).find('#sourceDisplay')[0].slideToggle();">source</a>
+            </li>
             <li>
                 <a class="" href="#submissionTop" onclick="return editsubmission(@Model.Id)">edit</a>
             </li>

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/_MessageSubmissionDetails.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/_MessageSubmissionDetails.cshtml
@@ -94,6 +94,7 @@
                     </form>
 
                 </div>
+				<textarea id="sourceDisplay" readonly="" class="form-control valid" style="display: none;">@Model.MessageContent</textarea>
             }
 
             @Html.Partial("~/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml", Model, new ViewDataDictionary { { "commentCount", commentCount } })

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
@@ -220,6 +220,7 @@
             </div>
 
         </form>
+		<textarea id="sourceDisplay" readonly="" class="form-control valid" style="display: none;">@WebUtility.HtmlDecode(commentModel.CommentContent)</textarea>
         @Html.Partial("~/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml", submissionViewModel)
     </div>
 </div>

--- a/Whoaverse/Whoaverse/Views/Shared/_MarkdownEditor.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_MarkdownEditor.cshtml
@@ -3,6 +3,11 @@
 
 
 <div class="markdownEditor">
+    <!-- Markdown Editor Link Sub Menu -->
+    <div class="markdownEditorSubMenu" id="linkSubMenu" style="display: none;">
+        <input type="text" class="markdownEditorTextButton" id="url" placeholder="Enter the page url">
+		<a class="markdownEditorTextButton" alt="create" title="Create Link" onclick="addHyperlink($(this.parentElement.parentElement.parentElement).find('textarea')[0],$(this.parentElement).find('#url')[0].value);">Create link</a>
+    </div>
     <!-- Markdown Editor Headings Sub Menu -->
     <div class="markdownEditorSubMenu" id="headingsSubMenu" style="display: none;">
         <a class="markdownEditorImgButton" style="background-position: -0px -32px;" alt="h1" title="Heading Level 1" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'\n#','');"></a>
@@ -20,13 +25,13 @@
         <a class="markdownEditorImgButton" style="background-position: -32px -48px;" alt="less_column" title="Less Columns" onclick="decColumns($(this.parentElement).find('#numCols')[0],$(this.parentElement).find('#numColsDisplay')[0]);"></a>
         <a class="markdownEditorImgButton" style="background-position: -64px -48px;" alt="more_rows" title="More Rows" onclick="incRows($(this.parentElement).find('#numRows')[0],$(this.parentElement).find('#numRowsDisplay')[0]);"></a>
         <a class="markdownEditorImgButton" style="background-position: -96px -48px;" alt="less_rows" title="Less Rows" onclick="decRows($(this.parentElement).find('#numRows')[0],$(this.parentElement).find('#numRowsDisplay')[0]);"></a>
-        <a class="markdownEditorTextButton" alt="create" title="Create Table" onclick="createTable($(this.parentElement.parentElement.parentElement).find('textarea')[0],this.parentElement.children[0].value,this.parentElement.children[1].value);">Create <span id="numColsDisplay">1</span>x<span id="numRowsDisplay">1</span> table</a>
+        <a class="markdownEditorTextButton" alt="create" title="Create Table" onclick="createTable($(this.parentElement.parentElement.parentElement).find('textarea')[0],$(this.parentElement).find('#numCols')[0].value,$(this.parentElement).find('#numRows')[0].value);">Create <span id="numColsDisplay">1</span>x<span id="numRowsDisplay">1</span> table</a>
     </div>
     <!-- Markdown Editor Main Menu -->
     <div class="markdownEditorMainMenu">
         <a class="markdownEditorImgButton" style="background-position: 0px 0px;" alt="bold" title="Bold" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'**','**');"></a>
         <a class="markdownEditorImgButton" style="background-position: -32px 0px;" alt="italic" title="Italic" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'*','*');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -64px 0px;" alt="link" title="Link" onclick="addHyperlink($(this.parentElement.parentElement.parentElement).find('textarea')[0]);"></a>
+        <a class="markdownEditorImgButton" style="background-position: -64px 0px;" alt="link" title="Link" onclick="$(this.parentElement.parentElement).find('#linkSubMenu').slideToggle();"></a>
         <a class="markdownEditorImgButton" style="background-position: -96px 0px;" alt="quote" title="Quote" onclick="addTagsToEachSelectedTextLine($(this.parentElement.parentElement.parentElement).find('textarea')[0],'>','');"></a>
         <a class="markdownEditorImgButton" style="background-position: -128px 0px;" alt="code" title="Code" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'~~~\n','\n~~~');"></a>
         <a class="markdownEditorImgButton" style="background-position: -160px 0px;" alt="ul" title="Bullet List" onclick="addTagsToEachSelectedTextLine($(this.parentElement.parentElement.parentElement).find('textarea')[0],'* ','');"></a>


### PR DESCRIPTION
Added a submenu to the markdown toolbar where the url for the link can be inserted, instead of using the browser's javascript input prompt.

Added three more examples to the markdown cheat sheet (unordered list, ordered list and horizontal rule)

Added a show source button beneath discussions and comments, so that users can see the markdown that was used instead of the finished html result