### PR TITLE
Updated source label behaviour and added comment's last edit time

### DIFF
--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -1044,3 +1044,14 @@ function showSubmissionPreview(senderButton) {
     return false;
 }
 
+// a function that toggles the visibility of the comment/submission source textarea
+function toggleSource(senderButton){
+	//toggle textarea visibility
+	$(senderButton.parentElement.parentElement.parentElement).find('#sourceDisplay').slideToggle();
+	//change label name according to current state
+	if (senderButton.text == "source"){
+		senderButton.text = "hide source";
+	} else {
+		senderButton.text = "source";
+	}
+}

--- a/Whoaverse/Whoaverse/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml
@@ -27,7 +27,7 @@
 
     @if (User.Identity.IsAuthenticated)
     {
-        if (User.Identity.Name != "deleted" && User.Identity.Name != commentAuthor)
+        if (commentAuthor != "deleted" && User.Identity.Name != commentAuthor)
 		{
             <li>
                 <a class="" href="javascript:void(0)" onclick="$(this.parentElement.parentElement.parentElement).find('#sourceDisplay').slideToggle();">source</a>

--- a/Whoaverse/Whoaverse/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml
@@ -30,7 +30,7 @@
         if (commentAuthor != "deleted" && User.Identity.Name != commentAuthor)
 		{
             <li>
-                <a class="" href="javascript:void(0)" onclick="$(this.parentElement.parentElement.parentElement).find('#sourceDisplay').slideToggle();">source</a>
+                <a class="" href="javascript:void(0)" onclick="toggleSource(this);">source</a>
             </li>
 		}
 		if (User.Identity.Name == commentAuthor)

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml
@@ -23,7 +23,7 @@
 
     @if (User.Identity.IsAuthenticated)
     {
-		if (User.Identity.Name != "deleted" && User.Identity.Name != Model.Name)
+		if (Model.Name != "deleted" && User.Identity.Name != Model.Name)
 		{
 			<li>
                 <a class="" href="javascript:void(0)" onclick="$(this.parentElement.parentElement.parentElement).find('#sourceDisplay').slideToggle();">source</a>

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml
@@ -26,7 +26,7 @@
 		if (Model.Name != "deleted" && User.Identity.Name != Model.Name)
 		{
 			<li>
-                <a class="" href="javascript:void(0)" onclick="$(this.parentElement.parentElement.parentElement).find('#sourceDisplay').slideToggle();">source</a>
+                <a class="" href="javascript:void(0)" onclick="toggleSource(this);">source</a>
             </li>
 		}
         if (User.Identity.Name == Model.Name)

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
@@ -43,6 +43,12 @@
     string postAge = Submissions.CalcSubmissionAge(submissionDate);
     string opName = Model.Name;
     string commentAuthor = commentModel.Name;
+	
+	DateTime lastEditDate = commentModel.LastEditDate;
+	string editedPostAge = "at some point in time";
+	if (lastEditDate != null){
+		editedPostAge = Submissions.CalcSubmissionAge(lastEditDate);
+	}
 
     string collapsedComment = "";
     string uncollapsedComment = "";
@@ -110,7 +116,11 @@
         {
             <span class="userattrs">[deleted]</span>
         }
-        <time title="@commentModel.Date" datetime="@commentModel.Date">@postAge</time>&#32;ago &nbsp;<a href="#" class="expand" style="@showIfParent" onclick="return showcomment(@commentId)">(show children)</a>
+        <time title="@commentModel.Date" datetime="@commentModel.Date">@postAge</time>&#32;ago&nbsp;
+		if (lastEditDate != null){
+			(last edited <time title="@commentModel.LastEditDate" datetime="@commentModel.LastEditDate">@editedPostAge</time>&#32;ago)
+		}
+		&nbsp;<a href="#" class="expand" style="@showIfParent" onclick="return showcomment(@commentId)">(show children)</a>
     </div>
 
     <div class="noncollapsed" id="@commentId" style="@uncollapsedComment">
@@ -183,7 +193,10 @@
                 <span class="userattrs">[deleted]</span>
             }
 
-            <time title="@commentModel.Date" datetime="@commentModel.Date">@postAge</time>&#32;ago
+            <time title="@commentModel.Date" datetime="@commentModel.Date">@postAge</time>&#32;ago&nbsp;
+			if (lastEditDate != null){
+				(last edited <time title="@commentModel.LastEditDate" datetime="@commentModel.LastEditDate">@editedPostAge</time>&#32;ago)
+			}
         </p>
 
         <form class="usertext" onsubmit="return editcommentsubmit(@commentId)" id="commenteditform-@commentId" action="#">


### PR DESCRIPTION
Took care of the things mentioned [here](https://github.com/whoaverse/whoaverse/pull/236#issuecomment-69928769).
- Source label should no longer be visible for deleted comments/submissions
- Source label is renamed to "hide source" when source is being shown, and renamed back to "source" when it is hidden

Additionally:

- Added comment's last edit time. it should look the same as it does now if the comment wasn't edited, and like this if comment is edited:

>DanielFlamino 1 points (+1|-0) 1 days ago (last edited 3 hours ago)