### PR TITLE
Changed Markdown Toolbar's submenus position and added comment preview

### DIFF
--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -1000,12 +1000,12 @@ function toggleSticky(messageId) {
     });
 }
 
-// a function to display a preview of submission without submitting it
-function showSubmissionPreview(senderButton) {
-    var rawSubmissionContent = $("#MessageContent").val();
+// a function to display a preview of a message without submitting it
+function showMessagePreview(senderButton, messageContent, previewArea) {
+    var rawSubmissionContent = $(messageContent).val();
     if (!rawSubmissionContent.length > 0) {
-        $("#submission-preview-area-container").html("Please enter a message in order to get a preview.");
-        $("#submission-preview-area").show();
+        $(previewArea).find("#submission-preview-area-container").html("Please enter a message in order to get a preview.");
+        $(previewArea).show();
         return false;
     }
 
@@ -1013,7 +1013,7 @@ function showSubmissionPreview(senderButton) {
 
     // get rendered submission and show it
     var submissionModel = {
-        MessageContent: $("#MessageContent").val()
+        MessageContent: $(messageContent).val()
     };
 
     $.ajax({
@@ -1021,13 +1021,13 @@ function showSubmissionPreview(senderButton) {
         type: 'post',
         dataType: 'html',
         success: function (data) {
-            $("#submission-preview-area-container").html(data);
+            $(previewArea).find("#submission-preview-area-container").html(data);
         },
         data: submissionModel
     });
 
     // show the preview area
-    $("#submission-preview-area").show();
+    $(previewArea).show();
     $(senderButton).val("Preview");
     return false;
 }

--- a/Whoaverse/Whoaverse/Views/AjaxViews/_CommentReplyForm.cshtml
+++ b/Whoaverse/Whoaverse/Views/AjaxViews/_CommentReplyForm.cshtml
@@ -42,9 +42,22 @@
         </div>
 
         <input type="button" id="submitbutton" value="Submit reply" class="btn-whoaverse-paging" onclick="postCommentReplyAjax(this, @messageId, '@User.Identity.Name', @parentCommentId)">
+		<input type="button" id="previewButton" value="Preview" class="btn-whoaverse-paging" onclick="showMessagePreview(this,$(this.parentElement).find('#CommentContent'),$(this.parentElement).find('#submission-preview-area'))">
         <button class="btn-whoaverse-paging" onclick="removereplyform(@parentCommentId);" type="button">Cancel</button>
         <br>
         <br />
+		<div class="panel panel-default" id="submission-preview-area" style="display: none">
+            <div class="panel-heading">
+                <h4 class="panel-title">Preview</h4>
+            </div>
+            <div class="panel-body">
+                <div class="usertext-body may-blank-within">
+                    <div class="md" id="submission-preview-area-container">
+                        Loading preview...
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>    
 
 </div>

--- a/Whoaverse/Whoaverse/Views/Shared/_AddComment.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_AddComment.cshtml
@@ -38,5 +38,19 @@
         </ul>
     </div>
     <input type="button" id="submitbutton" value="Submit comment" class="btn-whoaverse-paging" onclick="postCommentAjax(this, @messageId, '@User.Identity.Name')">
-    <div class="spacer"></div>
+	<input type="button" id="previewButton" value="Preview" class="btn-whoaverse-paging" onclick="showMessagePreview(this,$(this.parentElement).find('#CommentContent'),$(this.parentElement).find('#submission-preview-area'))">
+    <br><br>
+	<div class="panel panel-default" id="submission-preview-area" style="display: none">
+		<div class="panel-heading">
+			<h4 class="panel-title">Preview</h4>
+		</div>
+		<div class="panel-body">
+			<div class="usertext-body may-blank-within">
+				<div class="md" id="submission-preview-area-container">
+					Loading preview...
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="spacer"></div>
 }

--- a/Whoaverse/Whoaverse/Views/Shared/_AddSubmissionSelfpost.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_AddSubmissionSelfpost.cshtml
@@ -132,7 +132,7 @@
         <div class="form-group">
             <div class="col-md-offset-2 col-md-10">
                 <input type="submit" value="Submit" class="btn-whoaverse" />
-                <input type="button" value="Preview" class="btn-whoaverse" onclick="showSubmissionPreview(this)" />
+				<input type="button" value="Preview" class="btn-whoaverse" onclick="showMessagePreview(this,$(this.parentElement.parentElement.parentElement).find('#MessageContent'),$(this.parentElement.parentElement.parentElement).find('#submission-preview-area'))">
             </div>
         </div>
 

--- a/Whoaverse/Whoaverse/Views/Shared/_AddSubmissionSelfpost.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_AddSubmissionSelfpost.cshtml
@@ -180,8 +180,8 @@
                                             <td><b>bold</b></td>
                                         </tr>
                                         <tr>
-                                            <td>[Yay, a Google!](http://google.com)</td>
-                                            <td><a href="http://google.com">Yay, a Google!</a></td>
+                                            <td>[A website](http://example.com)</td>
+                                            <td><a href="http://example.com">A website</a></td>
                                         </tr>
                                     </tbody>
                                 </table>

--- a/Whoaverse/Whoaverse/Views/Shared/_MarkdownEditor.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_MarkdownEditor.cshtml
@@ -3,6 +3,20 @@
 
 
 <div class="markdownEditor">
+    <!-- Markdown Editor Main Menu -->
+    <div class="markdownEditorMainMenu">
+        <a class="markdownEditorImgButton" style="background-position: 0px 0px;" alt="bold" title="Bold" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'**','**');"></a>
+        <a class="markdownEditorImgButton" style="background-position: -32px 0px;" alt="italic" title="Italic" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'*','*');"></a>
+        <a class="markdownEditorImgButton" style="background-position: -64px 0px;" alt="link" title="Link" onclick="$(this.parentElement.parentElement).find('#linkSubMenu').toggle();"></a>
+        <a class="markdownEditorImgButton" style="background-position: -96px 0px;" alt="quote" title="Quote" onclick="addTagsToEachSelectedTextLine($(this.parentElement.parentElement.parentElement).find('textarea')[0],'>','');"></a>
+        <a class="markdownEditorImgButton" style="background-position: -128px 0px;" alt="code" title="Code" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'~~~\n','\n~~~');"></a>
+        <a class="markdownEditorImgButton" style="background-position: -160px 0px;" alt="ul" title="Bullet List" onclick="addTagsToEachSelectedTextLine($(this.parentElement.parentElement.parentElement).find('textarea')[0],'* ','');"></a>
+        <a class="markdownEditorImgButton" style="background-position: -192px 0px;" alt="ol" title="Number List" onclick="addTagsToEachSelectedTextLine($(this.parentElement.parentElement.parentElement).find('textarea')[0],'1. ','');"></a>
+        <a class="markdownEditorImgButton" style="background-position: -224px 0px;" alt="br" title="Large Paragraph Spacing" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'\n\n&amp;nbsp;\n\n','');"></a>
+        <a class="markdownEditorImgButton" style="background-position: -0px -16px;" alt="hr" title="Horizontal Rule" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'\n\n----------\n\n','');"></a>
+        <a class="markdownEditorImgButton" style="background-position: -32px -16px;" alt="heading" title="Headings" onclick="$(this.parentElement.parentElement).find('#headingsSubMenu').toggle();"></a>
+        <a class="markdownEditorImgButton" style="background-position: -64px -16px;" alt="table" title="Table" onclick="$(this.parentElement.parentElement).find('#tableCreatorSubMenu').toggle();"></a>
+    </div>
     <!-- Markdown Editor Link Sub Menu -->
     <div class="markdownEditorSubMenu" id="linkSubMenu" style="display: none;">
         <input type="text" class="markdownEditorTextButton" id="url" placeholder="Enter the page url">
@@ -26,19 +40,5 @@
         <a class="markdownEditorImgButton" style="background-position: -64px -48px;" alt="more_rows" title="More Rows" onclick="incRows($(this.parentElement).find('#numRows')[0],$(this.parentElement).find('#numRowsDisplay')[0]);"></a>
         <a class="markdownEditorImgButton" style="background-position: -96px -48px;" alt="less_rows" title="Less Rows" onclick="decRows($(this.parentElement).find('#numRows')[0],$(this.parentElement).find('#numRowsDisplay')[0]);"></a>
         <a class="markdownEditorTextButton" alt="create" title="Create Table" onclick="createTable($(this.parentElement.parentElement.parentElement).find('textarea')[0],$(this.parentElement).find('#numCols')[0].value,$(this.parentElement).find('#numRows')[0].value);">Create <span id="numColsDisplay">1</span>x<span id="numRowsDisplay">1</span> table</a>
-    </div>
-    <!-- Markdown Editor Main Menu -->
-    <div class="markdownEditorMainMenu">
-        <a class="markdownEditorImgButton" style="background-position: 0px 0px;" alt="bold" title="Bold" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'**','**');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -32px 0px;" alt="italic" title="Italic" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'*','*');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -64px 0px;" alt="link" title="Link" onclick="$(this.parentElement.parentElement).find('#linkSubMenu').toggle();"></a>
-        <a class="markdownEditorImgButton" style="background-position: -96px 0px;" alt="quote" title="Quote" onclick="addTagsToEachSelectedTextLine($(this.parentElement.parentElement.parentElement).find('textarea')[0],'>','');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -128px 0px;" alt="code" title="Code" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'~~~\n','\n~~~');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -160px 0px;" alt="ul" title="Bullet List" onclick="addTagsToEachSelectedTextLine($(this.parentElement.parentElement.parentElement).find('textarea')[0],'* ','');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -192px 0px;" alt="ol" title="Number List" onclick="addTagsToEachSelectedTextLine($(this.parentElement.parentElement.parentElement).find('textarea')[0],'1. ','');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -224px 0px;" alt="br" title="Large Paragraph Spacing" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'\n\n&amp;nbsp;\n\n','');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -0px -16px;" alt="hr" title="Horizontal Rule" onclick="addTagsToSelectedText($(this.parentElement.parentElement.parentElement).find('textarea')[0],'\n\n----------\n\n','');"></a>
-        <a class="markdownEditorImgButton" style="background-position: -32px -16px;" alt="heading" title="Headings" onclick="$(this.parentElement.parentElement).find('#headingsSubMenu').toggle();"></a>
-        <a class="markdownEditorImgButton" style="background-position: -64px -16px;" alt="table" title="Table" onclick="$(this.parentElement.parentElement).find('#tableCreatorSubMenu').toggle();"></a>
     </div>
 </div>


### PR DESCRIPTION
* Moved the submenus below the toolbar as requested [here](https://voat.co/v/voatdev/comments/40844)

* Changed showSubmissionPreview function so that it can be used in other places (instead of only for the Start a Discussion form)

* Updated the Preview button on the Start a Discussion form to reflect the change mentioned above

* Added [Preview button and Preview area to the compose submission comment form](https://i.imgur.com/rqSvf6c.png)

* Added [Preview button and Preview area to the compose comment reply form](https://i.imgur.com/zG6LGJl.png)