### PR TITLE
Changed "source" textarea css class and link expandos should appear in previews

### DIFF
--- a/Whoaverse/Whoaverse/Scripts/whoaverse.js
+++ b/Whoaverse/Whoaverse/Scripts/whoaverse.js
@@ -1022,6 +1022,7 @@ function showMessagePreview(senderButton, messageContent, previewArea) {
         dataType: 'html',
         success: function (data) {
             $(previewArea).find("#submission-preview-area-container").html(data);
+			UI.ExpandoManager.execute();
         },
         data: submissionModel
     });

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/_MessageSubmissionDetails.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/_MessageSubmissionDetails.cshtml
@@ -94,7 +94,7 @@
                     </form>
 
                 </div>
-				<textarea id="sourceDisplay" readonly="" class="form-control valid" style="display: none;">@Model.MessageContent</textarea>
+				<textarea id="sourceDisplay" readonly="" class="commenttextarea" style="display: none;">@Model.MessageContent</textarea>
             }
 
             @Html.Partial("~/Views/Shared/Submissions/SubmissionFlatListButtons/_MSFLButtons.cshtml", Model, new ViewDataDictionary { { "commentCount", commentCount } })

--- a/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/Submissions/_SubmissionComment.cshtml
@@ -233,7 +233,7 @@
             </div>
 
         </form>
-		<textarea id="sourceDisplay" readonly="" class="form-control valid" style="display: none;">@WebUtility.HtmlDecode(commentModel.CommentContent)</textarea>
+		<textarea id="sourceDisplay" readonly="" class="commenttextarea" style="display: none;">@WebUtility.HtmlDecode(commentModel.CommentContent)</textarea>
         @Html.Partial("~/Views/Shared/Comments/CommentFlatListButtons/_CommentFlatListButtons.cshtml", submissionViewModel)
     </div>
 </div>

--- a/Whoaverse/Whoaverse/Views/Shared/_MarkdownEditor.cshtml
+++ b/Whoaverse/Whoaverse/Views/Shared/_MarkdownEditor.cshtml
@@ -20,7 +20,7 @@
     <!-- Markdown Editor Link Sub Menu -->
     <div class="markdownEditorSubMenu" id="linkSubMenu" style="display: none;">
         <input type="text" class="markdownEditorTextButton" id="url" placeholder="Enter the page url">
-		<a class="markdownEditorTextButton" alt="create" title="Create Link" onclick="addHyperlink($(this.parentElement.parentElement.parentElement).find('textarea')[0],$(this.parentElement).find('#url')[0].value);$(this.parentElement).toggle();">Create link</a>
+		<a class="markdownEditorTextButton" alt="create" title="Create Link" onclick="addHyperlink($(this.parentElement.parentElement.parentElement).find('textarea')[0],$(this.parentElement).find('#url')[0].value);$(this.parentElement).hide();$(this.parentElement).find('#url')[0].value = '';">Create link</a>
     </div>
     <!-- Markdown Editor Headings Sub Menu -->
     <div class="markdownEditorSubMenu" id="headingsSubMenu" style="display: none;">


### PR DESCRIPTION
- Changed "source" textarea's class attribute to be the same as the class for the "edit comment" textarea (because this one already has night mode support and, since the source textarea is supposed to give other users the feeling as if they were editing other comments, looks exactly like the edit comment textarea. In case I wasn't clear enough: before ([light](https://i.imgur.com/kUAEhcg.png)/[dark](https://i.imgur.com/pJjRysy.png)) and after ([light](https://i.imgur.com/aR7eByU.png)/[dark](https://i.imgur.com/mgYKna8.png))

- Link expandos should now appear in previews ([Starting a Discussion](https://i.imgur.com/KKE8AVy.png)/[Compose Comment](https://i.imgur.com/zMt9Gyt.png)/[Comment Reply](https://i.imgur.com/scyQPSa.png))

That's all folks!

EDIT: That's not all folks!

- After clicking the "Create Link" button on the markdown toolbar, whatever url was in the input field should now be cleared, so that the user doesn't have to clear it himself the next time he uses it.