### PR TITLE
User Content Processor + Filters

### DIFF
--- a/Whoaverse/Whoaverse/Controllers/CommentController.cs
+++ b/Whoaverse/Whoaverse/Controllers/CommentController.cs
@@ -221,7 +221,7 @@ namespace Voat.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [System.Web.Mvc.Authorize]
-        [PreventSpam(DelayRequest = 120, ErrorMessage = "Sorry, you are doing that too fast. Please try again later.")]
+        [PreventSpam(DelayRequest = 15, ErrorMessage = "Sorry, you are doing that too fast. Please try again later.")]
         public async Task<ActionResult> EditComment([Bind(Include = "CommentId, CommentContent")] EditComment model)
         {
             if (!ModelState.IsValid) return Json("HTML is not allowed.", JsonRequestBehavior.AllowGet);

--- a/Whoaverse/Whoaverse/Controllers/HomeController.cs
+++ b/Whoaverse/Whoaverse/Controllers/HomeController.cs
@@ -24,6 +24,7 @@ using Microsoft.AspNet.SignalR;
 using Voat.Models;
 using Voat.Models.ViewModels;
 using Voat.Utils;
+using Voat.Utils.Components;
 
 namespace Voat.Controllers
 {
@@ -236,7 +237,17 @@ namespace Voat.Controllers
                     _db.Messages.Add(message);
                     // update last submission received date for target subverse
                     targetSubverse.last_submission_received = DateTime.Now;
+
+                    if (ContentProcessor.Instance.HasStage(ProcessingStage.InboundPreSave)) {
+                        message.MessageContent = ContentProcessor.Instance.Process(message.MessageContent, ProcessingStage.InboundPreSave, message);
+                    }
+
                     await _db.SaveChangesAsync();
+
+                    if (ContentProcessor.Instance.HasStage(ProcessingStage.InboundPostSave)) {
+                        ContentProcessor.Instance.Process(message.MessageContent, ProcessingStage.InboundPostSave, message);
+                    }
+
                 }
 
                 return RedirectToRoute(

--- a/Whoaverse/Whoaverse/Utils/Components/ContentFilters.cs
+++ b/Whoaverse/Whoaverse/Utils/Components/ContentFilters.cs
@@ -115,6 +115,23 @@ namespace Voat.Utils.Components {
             return replacer.Replace(content, context);
         }
     }
+
+    public class RedditLinkFilter : ContentFilter {
+        public RedditLinkFilter() {
+            ProcessingStage = ProcessingStage.Outbound;
+            Priority = 10;
+            IsReadOnly = false;
+
+        }
+        protected override string ProcessContent(string content, object context) {
+            MatchProcessingReplacer replacer = new MatchProcessingReplacer(@"(?<=\s{1,}|^)((/r/)(?'sub'[a-zA-Z0-9]+))",
+                delegate(Match m, object state) {
+                    return String.Format("[{0}](http://np.reddit.com{0})", m.Value);
+                }
+            );
+            return replacer.Replace(content, context);
+        }
+    }
      public class RawHyperlinkFilter : ContentFilter {
         public RawHyperlinkFilter() {
             ProcessingStage = ProcessingStage.Outbound;

--- a/Whoaverse/Whoaverse/Utils/Components/ContentFilters.cs
+++ b/Whoaverse/Whoaverse/Utils/Components/ContentFilters.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.Routing;
+using Voat.Models;
+
+namespace Voat.Utils.Components {
+
+    public abstract class ContentFilter {
+        private ProcessingStage _stage = ProcessingStage.InboundPostSave;
+        private int _priority = 0;
+        private bool _isReadOnly = false;
+
+        public bool IsReadOnly {
+            get { return _isReadOnly; }
+            set { _isReadOnly = value; }
+        }
+
+        public int Priority {
+            get { return _priority; }
+            set { _priority = value; }
+        }
+        public ProcessingStage ProcessingStage {
+            get { return _stage; }
+            set { _stage = value; }
+        }
+        public virtual string Process(string content, object context) {
+            string processedContent = ProcessContent(content, context);
+            return processedContent;
+        }
+        protected abstract string ProcessContent(string content, object context);
+
+    }
+    [Flags]
+    public enum ProcessingStage {
+        InboundPreSave = 1,
+        InboundPostSave = 2,
+        Outbound = 4
+    }
+    public class ContentFilterEventArgs : EventArgs {
+        public string Content { get; private set; }
+        public ContentFilterEventArgs(string content) {
+            this.Content = content;
+        }
+    }
+    #region Filter Classes
+    public abstract class UserMentionFilter : ContentFilter { 
+        protected RegExReplacer _replacer;
+        public UserMentionFilter(int matchThreshold, bool ignoreDuplicatMatches){
+            _replacer = new RegExReplacer();
+            // -> @user & /u/user
+            _replacer.Replacers.Add(new MatchProcessingReplacer(@"(?<=\s{1,}|^)((@|/u/)(?'user'[a-zA-Z0-9-_]+))", MatchFound) { MatchThreshold = matchThreshold, IgnoreDuplicateMatches = ignoreDuplicatMatches });
+        }
+
+        protected override string ProcessContent(string content, object context) {
+            return _replacer.Replace(content, context);
+        }
+
+        public abstract string MatchFound(Match match, object context);
+
+    
+    }
+    public class UserMentionNotificationFilter : UserMentionFilter {
+        public UserMentionNotificationFilter() : base(5, true) {
+            Priority = 1;
+            ProcessingStage = ProcessingStage.InboundPostSave;
+            IsReadOnly = true;
+        }
+        public override string MatchFound(Match match, object context) {
+            //Comment mentions
+            Comment c = context as Comment;
+            if (c != null && c.LastEditDate == null) {
+                NotificationManager.SendUserMentionNotification(match.Groups["user"].Value, c);
+            }
+            //Message mentions
+            Message m = context as Message;
+            if (m != null && m.LastEditDate == null) {
+                NotificationManager.SendUserMentionNotification(match.Groups["user"].Value, m);
+            }
+            return match.Value;
+        }
+    }
+
+    public class UserMentionLinkFilter : UserMentionFilter {
+        public UserMentionLinkFilter() : base(0, false) {
+            ProcessingStage = ProcessingStage.Outbound;
+            IsReadOnly = false;
+        }
+
+        public override string MatchFound(Match match, object context) {
+            var u = new UrlHelper(HttpContext.Current.Request.RequestContext, RouteTable.Routes);
+            return String.Format(" [{0}]({1})", match.Value, u.Action( "UserProfile", "Home", new { id = match.Groups["user"] }));
+        }
+    }
+    
+    public class SubverseLinkFilter : ContentFilter {
+        public SubverseLinkFilter() {
+            ProcessingStage = ProcessingStage.Outbound;
+            Priority = 10;
+            IsReadOnly = false;
+
+        }
+
+        protected override string ProcessContent(string content, object context) {
+            MatchProcessingReplacer replacer = new MatchProcessingReplacer(@"(?<=\s{1,}|^)((/v/)(?'sub'[a-zA-Z0-9]+))", 
+                delegate(Match m, object state) {
+                    var u = new UrlHelper(HttpContext.Current.Request.RequestContext, RouteTable.Routes);
+                    return String.Format("[{0}]({0})", u.Action("SubverseIndex", "Subverses", new { subversetoshow = m.Groups["sub"] }));
+                }
+            );
+            return replacer.Replace(content, context);
+        }
+    }
+     public class RawHyperlinkFilter : ContentFilter {
+        public RawHyperlinkFilter() {
+            ProcessingStage = ProcessingStage.Outbound;
+            Priority = 0;
+            IsReadOnly = false;
+
+        }
+
+        protected override string ProcessContent(string content, object context) {
+            MatchProcessingReplacer replacer = new MatchProcessingReplacer(@"(?<!\(\s{0,})(ht|f)tp(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&amp;%\$#_]*)(?<![\.\?\-_\,]|\s{1,})", 
+                delegate(Match m, object state) {
+                    return String.Format("[{0}]({0})",m.Value);
+                }
+            );
+            return replacer.Replace(content, context);
+        }
+    }
+    #endregion
+
+
+}

--- a/Whoaverse/Whoaverse/Utils/Components/ContentProcessor.cs
+++ b/Whoaverse/Whoaverse/Utils/Components/ContentProcessor.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Voat.Utils.Components {
+    public class ContentProcessor {
+
+        private List<ContentFilter> _filters = new List<ContentFilter>();
+        private static ContentProcessor _instance = null;
+
+        public List<ContentFilter> Filters {
+            get { return _filters; }
+            set { _filters = value; }
+        }
+
+        public static ContentProcessor Instance {
+            get {
+                if (_instance == null) {
+                    lock (typeof(ContentProcessor)) {
+                        if (_instance == null) {
+                            var p = new ContentProcessor();
+                            p.Filters.AddRange(new ContentFilter[] {
+                                new UserMentionNotificationFilter(), 
+                                new UserMentionLinkFilter(),
+                                new SubverseLinkFilter(),
+                                new RawHyperlinkFilter() });
+                            _instance = p;
+                        }
+                    }
+                }
+                return _instance;
+            }
+        }
+        public bool HasStage(ProcessingStage stage) {
+            return Filters.Exists(x => (stage & x.ProcessingStage) > 0);
+        }
+        public string Process(string content, ProcessingStage stage, object context) {
+            string c = content;
+            var inbound = Filters.FindAll(x => (stage & x.ProcessingStage) > 0).OrderByDescending(x => x.Priority).ToList();
+            inbound.ForEach(y => c = y.Process(c, context));
+            return c;
+        }
+        
+    }
+   
+
+}

--- a/Whoaverse/Whoaverse/Utils/Components/ContentProcessor.cs
+++ b/Whoaverse/Whoaverse/Utils/Components/ContentProcessor.cs
@@ -24,7 +24,8 @@ namespace Voat.Utils.Components {
                                 new UserMentionNotificationFilter(), 
                                 new UserMentionLinkFilter(),
                                 new SubverseLinkFilter(),
-                                new RawHyperlinkFilter() });
+                                new RawHyperlinkFilter(),
+                                new RedditLinkFilter()});
                             _instance = p;
                         }
                     }

--- a/Whoaverse/Whoaverse/Utils/Components/NotificationManager.cs
+++ b/Whoaverse/Whoaverse/Utils/Components/NotificationManager.cs
@@ -1,0 +1,183 @@
+﻿using Microsoft.AspNet.SignalR;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using Voat.Models;
+
+namespace Voat.Utils.Components {
+    public static class NotificationManager {
+
+        public static async Task SendUserMentionNotification(string user, Comment comment) {
+            if (comment != null) {
+              
+
+                if (!User.UserExists(user)) {
+                    return;
+                }
+
+                var commentReplyNotification = new Commentreplynotification();
+                using (var _db = new whoaverseEntities()) {
+                    
+                    commentReplyNotification.CommentId = comment.Id;
+                    commentReplyNotification.SubmissionId = comment.Message.Id;
+                    commentReplyNotification.Recipient = user;
+                    if (comment.Message.Anonymized || comment.Message.Subverses.anonymized_mode) {
+                        commentReplyNotification.Sender = (new Random()).Next(10000, 20000).ToString(CultureInfo.InvariantCulture);
+                    } else {
+                        commentReplyNotification.Sender = comment.Name;
+                    }
+                    commentReplyNotification.Body = comment.CommentContent;
+                    commentReplyNotification.Subverse = comment.Message.Subverse;
+                    commentReplyNotification.Status = true;
+                    commentReplyNotification.Timestamp = DateTime.Now;
+
+                    commentReplyNotification.Subject = String.Format("@{0} mentioned you in a comment", comment.Name, comment.Message.Title);
+
+                    _db.Commentreplynotifications.Add(commentReplyNotification);
+                    await _db.SaveChangesAsync();
+                }
+                // get count of unread notifications
+                int unreadNotifications = Utils.User.UnreadTotalNotificationsCount(commentReplyNotification.Recipient);
+
+                // send SignalR realtime notification to recipient
+                var hubContext = GlobalHost.ConnectionManager.GetHubContext<MessagingHub>();
+                hubContext.Clients.User(commentReplyNotification.Recipient).setNotificationsPending(unreadNotifications);
+            
+            }
+        }
+        public static async Task SendUserMentionNotification(string user, Message message) {
+            if (message != null) {
+
+
+                if (!User.UserExists(user)) {
+                    return;
+                }
+
+                var commentReplyNotification = new Commentreplynotification();
+                using (var _db = new whoaverseEntities()) {
+
+                    //commentReplyNotification.CommentId = comment.Id;
+                    commentReplyNotification.SubmissionId = message.Id;
+                    commentReplyNotification.Recipient = user;
+                    if (message.Anonymized || message.Subverses.anonymized_mode) {
+                        commentReplyNotification.Sender = (new Random()).Next(10000, 20000).ToString(CultureInfo.InvariantCulture);
+                    } else {
+                        commentReplyNotification.Sender = message.Name;
+                    }
+                    commentReplyNotification.Body = message.MessageContent;
+                    commentReplyNotification.Subverse = message.Subverse;
+                    commentReplyNotification.Status = true;
+                    commentReplyNotification.Timestamp = DateTime.Now;
+
+                    commentReplyNotification.Subject = String.Format("@{0} mentioned you in post '{1}'", message.Name, message.Title);
+
+                    _db.Commentreplynotifications.Add(commentReplyNotification);
+                    await _db.SaveChangesAsync();
+                }
+                // get count of unread notifications
+                int unreadNotifications = Utils.User.UnreadTotalNotificationsCount(commentReplyNotification.Recipient);
+
+                // send SignalR realtime notification to recipient
+                var hubContext = GlobalHost.ConnectionManager.GetHubContext<MessagingHub>();
+                hubContext.Clients.User(commentReplyNotification.Recipient).setNotificationsPending(unreadNotifications);
+
+            }
+        }
+        public static async Task SendCommentNotification(Comment comment) {
+
+            whoaverseEntities _db = new whoaverseEntities();
+            Random _rnd = new Random();
+
+            if (comment.ParentId != null && comment.CommentContent != null) {
+                // find the parent comment and its author
+                var parentComment = _db.Comments.Find(comment.ParentId);
+                if (parentComment != null) {
+                    // check if recipient exists
+                    if (Utils.User.UserExists(parentComment.Name)) {
+                        // do not send notification if author is the same as comment author
+                        if (parentComment.Name != System.Web.HttpContext.Current.User.Identity.Name) {
+                            // send the message
+
+                            var commentMessage = _db.Messages.Find(comment.MessageId);
+                            if (commentMessage != null) {
+                                var commentReplyNotification = new Commentreplynotification();
+                                commentReplyNotification.CommentId = comment.Id;
+                                commentReplyNotification.SubmissionId = commentMessage.Id;
+                                commentReplyNotification.Recipient = parentComment.Name;
+                                if (parentComment.Message.Anonymized || parentComment.Message.Subverses.anonymized_mode) {
+                                    commentReplyNotification.Sender = _rnd.Next(10000, 20000).ToString(CultureInfo.InvariantCulture);
+                                } else {
+                                    commentReplyNotification.Sender = System.Web.HttpContext.Current.User.Identity.Name;
+                                }
+                                commentReplyNotification.Body = comment.CommentContent;
+                                commentReplyNotification.Subverse = commentMessage.Subverse;
+                                commentReplyNotification.Status = true;
+                                commentReplyNotification.Timestamp = DateTime.Now;
+
+                                // self = type 1, url = type 2
+                                commentReplyNotification.Subject = parentComment.Message.Type == 1 ? parentComment.Message.Title : parentComment.Message.Linkdescription;
+
+                                _db.Commentreplynotifications.Add(commentReplyNotification);
+
+                                await _db.SaveChangesAsync();
+
+                                // get count of unread notifications
+                                int unreadNotifications = Utils.User.UnreadTotalNotificationsCount(commentReplyNotification.Recipient);
+
+                                // send SignalR realtime notification to recipient
+                                var hubContext = GlobalHost.ConnectionManager.GetHubContext<MessagingHub>();
+                                hubContext.Clients.User(commentReplyNotification.Recipient).setNotificationsPending(unreadNotifications);
+                            }
+                        }
+                    }
+                }
+            } else {
+                // comment reply is sent to a root comment which has no parent id, trigger post reply notification
+                var commentMessage = _db.Messages.Find(comment.MessageId);
+                if (commentMessage != null) {
+                    // check if recipient exists
+                    if (Utils.User.UserExists(commentMessage.Name)) {
+                        // do not send notification if author is the same as comment author
+                        if (commentMessage.Name != System.Web.HttpContext.Current.User.Identity.Name) {
+                            // send the message
+                            var postReplyNotification = new Postreplynotification();
+
+                            postReplyNotification.CommentId = comment.Id;
+                            postReplyNotification.SubmissionId = commentMessage.Id;
+                            postReplyNotification.Recipient = commentMessage.Name;
+
+                            if (commentMessage.Anonymized || commentMessage.Subverses.anonymized_mode) {
+                                postReplyNotification.Sender = _rnd.Next(10000, 20000).ToString(CultureInfo.InvariantCulture);
+                            } else {
+                                postReplyNotification.Sender = System.Web.HttpContext.Current.User.Identity.Name;
+                            }
+
+                            postReplyNotification.Body = comment.CommentContent;
+                            postReplyNotification.Subverse = commentMessage.Subverse;
+                            postReplyNotification.Status = true;
+                            postReplyNotification.Timestamp = DateTime.Now;
+
+                            // self = type 1, url = type 2
+                            postReplyNotification.Subject = commentMessage.Type == 1 ? commentMessage.Title : commentMessage.Linkdescription;
+
+                            _db.Postreplynotifications.Add(postReplyNotification);
+
+                            await _db.SaveChangesAsync();
+
+                            // get count of unread notifications
+                            int unreadNotifications = Utils.User.UnreadTotalNotificationsCount(postReplyNotification.Recipient);
+
+                            // send SignalR realtime notification to recipient
+                            var hubContext = GlobalHost.ConnectionManager.GetHubContext<MessagingHub>();
+                            hubContext.Clients.User(postReplyNotification.Recipient).setNotificationsPending(unreadNotifications);
+                        }
+                    }
+                } 
+            }
+        }
+
+    }
+}

--- a/Whoaverse/Whoaverse/Utils/Components/RegExReplacer.cs
+++ b/Whoaverse/Whoaverse/Utils/Components/RegExReplacer.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Web;
+
+namespace Voat.Utils.Components {
+    public interface IReplacer {
+        string Replace(string Content, object state);
+    }
+
+    public class RegExReplacer : IReplacer {
+        private List<IReplacer> _replacers = new List<IReplacer>();
+
+        public List<IReplacer> Replacers {
+            get { return this._replacers; }
+            set { this._replacers = value; }
+        }
+        public RegExReplacer(List<IReplacer> Replacers) {
+            this._replacers = Replacers;
+        }
+        public RegExReplacer() {
+        }
+        public string Replace(string Content, object state) {
+            foreach (IReplacer ir in _replacers) {
+                Content = ir.Replace(Content, state);
+            }
+            return Content;
+        }
+    }
+
+    public class MatchStripper : MatchReplacer {
+        private bool _stripwhitespacerepetitions = true;
+        private bool _stripreplacementrepetitions = true;
+
+        public bool StripReplacementRepetitions {
+            get { return _stripreplacementrepetitions; }
+            set { _stripreplacementrepetitions = value; }
+        }
+        private bool _trim = true;
+
+        public bool Trim {
+            get { return _trim; }
+            set { _trim = value; }
+        }
+
+        public MatchStripper(string ReplacementRegEx, string ReplacementValue) : base(ReplacementRegEx, ReplacementValue) { }
+
+        public bool StripWhitespaceRepetitions {
+            get { return _stripwhitespacerepetitions; }
+            set { _stripwhitespacerepetitions = value; }
+        }
+
+        public override string Replace(string Content, object state) {
+
+            string val = base.Replace(Content, state);
+            if (StripWhitespaceRepetitions) {
+                val = Regex.Replace(val, "\\s+", " ");
+            }
+            if (StripReplacementRepetitions && ReplacementValue != " " && !String.IsNullOrEmpty(ReplacementValue)) {
+                val = Regex.Replace(val, String.Format("({0})+", ReplacementValue), ReplacementValue);
+            }
+
+            return (Trim ? val.Trim() : val);
+        }
+    }
+    public class NullReplacer : IReplacer {
+        public string Replace(string Content, object state) {
+            return Content;
+        }
+    }
+    public class MatchReplacer : IReplacer {
+        #region IReplacer Members
+        private string _regex = "";
+        private string _replacementvalue = "";
+
+        public MatchReplacer(string ReplacementRegEx, string ReplacementValue) {
+            this.ReplacementRegEx = ReplacementRegEx;
+            this.ReplacementValue = ReplacementValue;
+        }
+        public string ReplacementRegEx {
+            get { return _regex; }
+            set { _regex = value; }
+        }
+        public string ReplacementValue {
+            get { return _replacementvalue; }
+            set { _replacementvalue = value; }
+        }
+        public virtual string Replace(string Content, object state) {
+            return Regex.Replace(Content, this.ReplacementRegEx, this.ReplacementValue);
+        }
+
+        #endregion
+    }
+    public class MatchProcessingReplacer : IReplacer {
+        #region IReplacer Members
+        private string _regex = "";
+        private Func<Match, object, string> _func;
+        private int _matchThreshold = 0;
+        private bool _ignoreDuplicateMatches = false;
+
+        public bool IgnoreDuplicateMatches {
+            get { return _ignoreDuplicateMatches; }
+            set { _ignoreDuplicateMatches = value; }
+        }
+
+        public int MatchThreshold {
+            get { return _matchThreshold; }
+            set { _matchThreshold = value; }
+        }
+
+        public MatchProcessingReplacer(string RegEx, Func<Match, object, string> Func) {
+            this.RegEx = RegEx;
+            this._func = Func;
+        }
+        public string RegEx {
+            get { return _regex; }
+            set { _regex = value; }
+        }
+
+        public virtual string Replace(string content, object state) {
+            MatchCollection matches = Regex.Matches(content, RegEx);
+            string result = content;
+            int offset = 0;
+            List<string> matchvalues = new List<string>();
+            int maxIndex = (MatchThreshold > 0) ? Math.Min(MatchThreshold, matches.Count) : matches.Count;
+
+            for (int i = 0; i < maxIndex; i++ ) {
+                Match m = matches[i];
+                if (!IgnoreDuplicateMatches || IgnoreDuplicateMatches && !matchvalues.Contains(m.Value)) { 
+                    string substitution = _func(m, state);
+                    result = result.Remove(m.Index + offset, m.Length).Insert(m.Index + offset, substitution);
+                    offset += substitution.Length - m.Length;
+                    matchvalues.Add(m.Value);
+                }
+            }
+            return result;
+        }
+
+        #endregion
+    }
+    public class DateReplacer : IReplacer {
+        private string regex = @"\[[dD]{1}[aA]{1}[tT]{1}[eE]{1}:(?<format>[a-zA-Z_0-9\.-]+)\]";
+
+        public string Replace(string Content, object state) {
+            string val = Content.ToString();
+            MatchCollection col = Regex.Matches(val, regex);
+            if (col.Count > 0) {
+                foreach (Match match in col) {
+                    string cmd = match.Value;
+                    string format = match.Groups[1].Value;
+
+                    val = val.Remove(match.Index, match.Length);
+                    //format
+                    DateTime dt = DateTime.Now;
+                    format = Regex.Replace(format, "([mM]{1}[nN]{1})", dt.Minute.ToString());
+                    format = Regex.Replace(format, "[mM]{2}", dt.Month.ToString().PadLeft(2, '0'));
+                    format = Regex.Replace(format, "[mM]{1}", dt.Month.ToString());
+                    format = Regex.Replace(format, "([dD]{2})", dt.Day.ToString().PadLeft(2, '0'));
+                    format = Regex.Replace(format, "([dD]{1})", dt.Day.ToString());
+                    format = Regex.Replace(format, "([yY]{4})", dt.Year.ToString());
+                    format = Regex.Replace(format, "([yY]{2})", dt.Year.ToString().Substring(2, 2));
+                    format = Regex.Replace(format, "([yY]{1})", dt.Year.ToString());
+                    format = Regex.Replace(format, "([hH]{1,2})", dt.Hour.ToString());
+                    format = Regex.Replace(format, "([sS]{1,2})", dt.Second.ToString());
+                    val = val.Insert(match.Index, format);
+                }
+            }
+            return val;
+        }
+    }
+   
+}

--- a/Whoaverse/Whoaverse/Utils/Formatting.cs
+++ b/Whoaverse/Whoaverse/Utils/Formatting.cs
@@ -14,17 +14,26 @@ All Rights Reserved.
 
 using System;
 using MarkdownDeep;
+using Voat.Utils.Components;
 
 namespace Voat.Utils
 {
     public static class Formatting
     {
         
-        public static string FormatMessage (String originalMessage){
+        public static string FormatMessage(String originalMessage, bool processContent = true){
+
+            if (processContent) { 
+                originalMessage = ContentProcessor.Instance.Process(originalMessage, ProcessingStage.Outbound, null);
+            }
+
             var m = new Markdown
             {
                 ExtraMode = true, 
-                SafeMode = true
+                SafeMode = true,
+                //I don't know why this logic was removed but it's back.... (evil laugh)
+                NewWindowForExternalLinks = Utils.User.LinksInNewWindow(System.Web.HttpContext.Current.User.Identity.Name),
+                NewWindowForLocalLinks = Utils.User.LinksInNewWindow(System.Web.HttpContext.Current.User.Identity.Name)
             };
 
             return m.Transform(originalMessage);

--- a/Whoaverse/Whoaverse/Views/Messaging/Inbox.cshtml
+++ b/Whoaverse/Whoaverse/Views/Messaging/Inbox.cshtml
@@ -27,14 +27,16 @@
 @Html.AntiForgeryToken()
 
 <div id="container">
-    <a href="/messaging/inbox/" class="btn-whoaverse-paging disabled">Private messages [@ViewBag.UnreadPrivateMessages]</a>
-    <a href="/messaging/commentreplies/" class="btn-whoaverse-paging">Comment replies [@ViewBag.UnreadCommentReplies]</a>
-    <a href="/messaging/postreplies/" class="btn-whoaverse-paging">Post replies [@ViewBag.UnreadPostReplies]</a>
+    <h1>Private Messages</h1>
+    <a href="/messaging/inbox/" class="btn-whoaverse-paging">Private Messages [@ViewBag.UnreadPrivateMessages]</a>
+    <a href="/messaging/commentreplies/" class="btn-whoaverse-paging">Comment Replies / User Mentions [@ViewBag.UnreadCommentReplies]</a>
+    <a href="/messaging/postreplies/" class="btn-whoaverse-paging">Post Replies [@ViewBag.UnreadPostReplies]</a>
     <div id="about-main" class="" role="main">
         <div class="md single-notification">
 
             @if (Model.Count > 0)
             {
+                
                 <p>Displaying newest @Model.Count message(s). Your Inbox contains a total of @ViewBag.InboxCount message(s).</p>
                 <hr />
 

--- a/Whoaverse/Whoaverse/Views/Messaging/InboxCommentReplies.cshtml
+++ b/Whoaverse/Whoaverse/Views/Messaging/InboxCommentReplies.cshtml
@@ -28,14 +28,16 @@
 @Html.AntiForgeryToken()
 
 <div id="container">
-    <a href="/messaging/inbox/" class="btn-whoaverse-paging">Private messages [@ViewBag.UnreadPrivateMessages]</a>
-    <a href="/messaging/commentreplies/" class="btn-whoaverse-paging disabled">Comment replies [@ViewBag.UnreadCommentReplies]</a>
-    <a href="/messaging/postreplies/" class="btn-whoaverse-paging">Post replies [@ViewBag.UnreadPostReplies]</a>
+    <h1>Comment & User Mention Notifications</h1>
+    <a href="/messaging/inbox/" class="btn-whoaverse-paging">Private Messages [@ViewBag.UnreadPrivateMessages]</a>
+    <a href="/messaging/commentreplies/" class="btn-whoaverse-paging">Comment Replies / User Mentions [@ViewBag.UnreadCommentReplies]</a>
+    <a href="/messaging/postreplies/" class="btn-whoaverse-paging">Post Replies [@ViewBag.UnreadPostReplies]</a>
     <div id="about-main" role="main">
         <div class="md single-notification">
 
             @if (Model.Count > 0)
             {
+               
                 <p>Displaying newest @Model.Count comment reply notifications. You have a total of @ViewBag.CommentRepliesCount comment reply notification(s).</p>
                 <hr />
 
@@ -69,7 +71,7 @@
                             </li>
                             <li>|</li>
                             <li>
-                                <a class="btn-whoaverse-paging" id="replyCommentNotification" href="javascript:void(0)" onclick="return replyToCommentNotification(@message.CommentId, @message.SubmissionId)">Reply</a>
+                                <a class="btn-whoaverse-paging @(message.CommentId <= 0 ? "disabled" : "")" id="replyCommentNotification" href="javascript:void(0)" onclick="return replyToCommentNotification(@message.CommentId, @message.SubmissionId)">Reply</a>
                             </li>
                         </ul>
                         <br /><br />

--- a/Whoaverse/Whoaverse/Views/Messaging/InboxPostReplies.cshtml
+++ b/Whoaverse/Whoaverse/Views/Messaging/InboxPostReplies.cshtml
@@ -29,13 +29,15 @@
 @Html.AntiForgeryToken()
 
 <div id="container">
-    <a href="/messaging/inbox/" class="btn-whoaverse-paging">Private messages [@ViewBag.UnreadPrivateMessages]</a>
-    <a href="/messaging/commentreplies/" class="btn-whoaverse-paging">Comment replies [@ViewBag.UnreadCommentReplies]</a>
-    <a href="/messaging/postreplies/" class="btn-whoaverse-paging disabled">Post replies [@ViewBag.UnreadPostReplies]</a>
+    <h1>Post Reply Notifications</h1>
+    <a href="/messaging/inbox/" class="btn-whoaverse-paging">Private Messages [@ViewBag.UnreadPrivateMessages]</a>
+    <a href="/messaging/commentreplies/" class="btn-whoaverse-paging">Comment Replies / User Mentions [@ViewBag.UnreadCommentReplies]</a>
+    <a href="/messaging/postreplies/" class="btn-whoaverse-paging">Post Replies [@ViewBag.UnreadPostReplies]</a>
     <div id="about-main" role="main">
         <div class="md single-notification">
             @if (Model.Count > 0)
             {
+                
                 <p>Displaying newest @Model.Count post reply notifications. You have a total of @ViewBag.PostRepliesCount post reply notification(s).</p>
                 <hr />
 

--- a/Whoaverse/Whoaverse/Voat.csproj
+++ b/Whoaverse/Whoaverse/Voat.csproj
@@ -288,6 +288,10 @@
     <Compile Include="Models\Viewstatistic.cs">
       <DependentUpon>WhoaverseEntityDataModel.tt</DependentUpon>
     </Compile>
+    <Compile Include="Utils\Components\ContentFilters.cs" />
+    <Compile Include="Utils\Components\ContentProcessor.cs" />
+    <Compile Include="Utils\Components\NotificationManager.cs" />
+    <Compile Include="Utils\Components\RegExReplacer.cs" />
     <Compile Include="Utils\HtmlHelperExtensions.cs" />
     <Compile Include="Utils\PaginatedList.cs" />
     <Compile Include="Controllers\PartnerController.cs" />


### PR DESCRIPTION
This update has the core prototypal structure to parse both incoming and
outgoing user content. Incoming filters process user mention
notifications and outgoing filters convert user mentions, subverse refs,
and raw urls into markdown format.

Both @user and /u/user syntax is supported for user notifications and
links. User notifications happen in all comments and during a post
creation if @user syntax is used in body of the post. Edited
comments/posts are ignored when sending user mention notifications.

User mentioning is limited to the first 5 valid matches, the rest are
ignored. In addition the user mention logic prevents duplicate
notifications if a user is mentioned more than once in a comment/post.

Some small code refactoring in areas I was working also took place.